### PR TITLE
chore: Match entire URL in the URL Intel RegEx.

### DIFF
--- a/langchain_prompt_protection/runnables/url_intel.py
+++ b/langchain_prompt_protection/runnables/url_intel.py
@@ -12,7 +12,7 @@ from pydantic import SecretStr
 
 __all__ = ["MaliciousUrlsError", "PangeaUrlIntelGuard"]
 
-URL_RE = r"https?://(?:[-\w.]|%[\da-fA-F]{2})+(?::\d+)?"
+URL_RE = r"https?://(?:[-\w.]|%[\da-fA-F]{2})+(?::\d+)?(?:/[\w./?%&=-]*)?"
 
 
 class MaliciousUrlsError(RuntimeError):


### PR DESCRIPTION
It appears CrowdStrike could be matching malicious URLs including paths and query strings. 