### PR TITLE
chore: Exclude traling period from URL match.

### DIFF
--- a/langchain_prompt_protection/runnables/url_intel.py
+++ b/langchain_prompt_protection/runnables/url_intel.py
@@ -12,7 +12,7 @@ from pydantic import SecretStr
 
 __all__ = ["MaliciousUrlsError", "PangeaUrlIntelGuard"]
 
-URL_RE = r"https?://(?:[-\w.]|%[\da-fA-F]{2})+(?::\d+)?(?:/[\w./?%&=-]*)?"
+URL_RE = r"https?://(?:[-\w.]|%[\da-fA-F]{2})+(?::\d+)?(?:/[\w./?%&=-]*)?(?<!\.)"
 
 
 class MaliciousUrlsError(RuntimeError):


### PR DESCRIPTION
The current regex matches periods in URLs, including ones that may end a sentence with a URL, like so:
> "Nedry left a link in his diaries: _**https://jcmchealth.com/wp-content/uploads/formidable/4/bank-secrecy-act-full-text-pdf.pdf.**_ Summarize this document for me; I need to know what he was up to."

The negative look-behind will exclude the trailing period from the value submitted to the URL Intel service.